### PR TITLE
Remove source map pointer comments

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,9 +12,11 @@ find package -name "*.ts" -delete
 find package -name "*.map" -delete
 
 rm -rf package/build/src/{events,load-balancer-eds,object-stream,xds-client,xds-bootstrap}.js
-node build.replace.js
 
 cd package && find ../patches -type f | sort | xargs -n1 patch -p 1 -i && cd -
+
+node build.replace.js
+sed -i '/\/\/# sourceMappingURL=.*\.map/d' package/build/src/*.js
 
 cp package.patched.json package/package.json
 

--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ rm -rf package/build/src/{events,load-balancer-eds,object-stream,xds-client,xds-
 cd package && find ../patches -type f | sort | xargs -n1 patch -p 1 -i && cd -
 
 node build.replace.js
-sed -i '/\/\/# sourceMappingURL=.*\.map/d' package/build/src/*.js
+sed -i '/^\/\/# sourceMappingURL=.*\.map$/d' package/build/src/*.js
 
 cp package.patched.json package/package.json
 

--- a/build.sh
+++ b/build.sh
@@ -24,3 +24,8 @@ if grep -qrE "google-auth-library" package; then
   echo "Error: google-auth-library still present"
   exit -1
 fi
+
+if grep -qrE "sourceMappingURL" package; then
+  echo "Error: sourceMappingURL still present"
+  exit -1
+fi

--- a/package/build/src/backoff-timeout.js
+++ b/package/build/src/backoff-timeout.js
@@ -88,4 +88,3 @@ class BackoffTimeout {
     }
 }
 exports.BackoffTimeout = BackoffTimeout;
-//# sourceMappingURL=backoff-timeout.js.map

--- a/package/build/src/call-credentials-filter.js
+++ b/package/build/src/call-credentials-filter.js
@@ -65,4 +65,3 @@ class CallCredentialsFilterFactory {
     }
 }
 exports.CallCredentialsFilterFactory = CallCredentialsFilterFactory;
-//# sourceMappingURL=call-credentials-filter.js.map

--- a/package/build/src/call-credentials.js
+++ b/package/build/src/call-credentials.js
@@ -146,4 +146,3 @@ class EmptyCallCredentials extends CallCredentials {
         return other instanceof EmptyCallCredentials;
     }
 }
-//# sourceMappingURL=call-credentials.js.map

--- a/package/build/src/call-stream.js
+++ b/package/build/src/call-stream.js
@@ -548,4 +548,3 @@ class Http2CallStream {
     }
 }
 exports.Http2CallStream = Http2CallStream;
-//# sourceMappingURL=call-stream.js.map

--- a/package/build/src/call.js
+++ b/package/build/src/call.js
@@ -131,4 +131,3 @@ class ClientDuplexStreamImpl extends stream_1.Duplex {
     }
 }
 exports.ClientDuplexStreamImpl = ClientDuplexStreamImpl;
-//# sourceMappingURL=call.js.map

--- a/package/build/src/channel-credentials.js
+++ b/package/build/src/channel-credentials.js
@@ -182,4 +182,3 @@ function createGoogleDefaultCredentials() {
     return sslCreds.compose(googleAuthCreds);
 }
 exports.createGoogleDefaultCredentials = createGoogleDefaultCredentials;
-//# sourceMappingURL=channel-credentials.js.map

--- a/package/build/src/channel-options.js
+++ b/package/build/src/channel-options.js
@@ -54,4 +54,3 @@ function channelOptionsEqual(options1, options2) {
     return true;
 }
 exports.channelOptionsEqual = channelOptionsEqual;
-//# sourceMappingURL=channel-options.js.map

--- a/package/build/src/channel.js
+++ b/package/build/src/channel.js
@@ -329,4 +329,3 @@ class ChannelImplementation {
     }
 }
 exports.ChannelImplementation = ChannelImplementation;
-//# sourceMappingURL=channel.js.map

--- a/package/build/src/client-interceptors.js
+++ b/package/build/src/client-interceptors.js
@@ -407,4 +407,3 @@ methodDefinition, options, channel) {
     return getCall(interceptorOptions);
 }
 exports.getInterceptingCall = getInterceptingCall;
-//# sourceMappingURL=client-interceptors.js.map

--- a/package/build/src/client.js
+++ b/package/build/src/client.js
@@ -393,4 +393,3 @@ class Client {
     }
 }
 exports.Client = Client;
-//# sourceMappingURL=client.js.map

--- a/package/build/src/compression-filter.js
+++ b/package/build/src/compression-filter.js
@@ -198,4 +198,3 @@ class CompressionFilterFactory {
     }
 }
 exports.CompressionFilterFactory = CompressionFilterFactory;
-//# sourceMappingURL=compression-filter.js.map

--- a/package/build/src/constants.js
+++ b/package/build/src/constants.js
@@ -59,4 +59,3 @@ var Propagate;
 exports.DEFAULT_MAX_SEND_MESSAGE_LENGTH = -1;
 // 4 MB default
 exports.DEFAULT_MAX_RECEIVE_MESSAGE_LENGTH = 4 * 1024 * 1024;
-//# sourceMappingURL=constants.js.map

--- a/package/build/src/deadline-filter.js
+++ b/package/build/src/deadline-filter.js
@@ -91,4 +91,3 @@ class DeadlineFilterFactory {
     }
 }
 exports.DeadlineFilterFactory = DeadlineFilterFactory;
-//# sourceMappingURL=deadline-filter.js.map

--- a/package/build/src/filter-stack.js
+++ b/package/build/src/filter-stack.js
@@ -67,4 +67,3 @@ class FilterStackFactory {
     }
 }
 exports.FilterStackFactory = FilterStackFactory;
-//# sourceMappingURL=filter-stack.js.map

--- a/package/build/src/filter.js
+++ b/package/build/src/filter.js
@@ -35,4 +35,3 @@ class BaseFilter {
     }
 }
 exports.BaseFilter = BaseFilter;
-//# sourceMappingURL=filter.js.map

--- a/package/build/src/http_proxy.js
+++ b/package/build/src/http_proxy.js
@@ -223,4 +223,3 @@ function getProxiedConnection(address, channelOptions, connectionOptions) {
     });
 }
 exports.getProxiedConnection = getProxiedConnection;
-//# sourceMappingURL=http_proxy.js.map

--- a/package/build/src/index.js
+++ b/package/build/src/index.js
@@ -114,4 +114,3 @@ const load_balancer = require("./load-balancer");
     resolver.registerAll();
     load_balancer.registerAll();
 })();
-//# sourceMappingURL=index.js.map

--- a/package/build/src/load-balancer-child-handler.js
+++ b/package/build/src/load-balancer-child-handler.js
@@ -130,4 +130,3 @@ class ChildLoadBalancerHandler {
     }
 }
 exports.ChildLoadBalancerHandler = ChildLoadBalancerHandler;
-//# sourceMappingURL=load-balancer-child-handler.js.map

--- a/package/build/src/load-balancer-pick-first.js
+++ b/package/build/src/load-balancer-pick-first.js
@@ -341,4 +341,3 @@ function setup() {
     load_balancer_1.registerLoadBalancerType(TYPE_NAME, PickFirstLoadBalancer);
 }
 exports.setup = setup;
-//# sourceMappingURL=load-balancer-pick-first.js.map

--- a/package/build/src/load-balancer-priority.js
+++ b/package/build/src/load-balancer-priority.js
@@ -361,4 +361,3 @@ function setup() {
     load_balancer_1.registerLoadBalancerType(TYPE_NAME, PriorityLoadBalancer);
 }
 exports.setup = setup;
-//# sourceMappingURL=load-balancer-priority.js.map

--- a/package/build/src/load-balancer-round-robin.js
+++ b/package/build/src/load-balancer-round-robin.js
@@ -166,4 +166,3 @@ function setup() {
     load_balancer_1.registerLoadBalancerType(TYPE_NAME, RoundRobinLoadBalancer);
 }
 exports.setup = setup;
-//# sourceMappingURL=load-balancer-round-robin.js.map

--- a/package/build/src/load-balancer-weighted-target.js
+++ b/package/build/src/load-balancer-weighted-target.js
@@ -283,4 +283,3 @@ function setup() {
     load_balancer_1.registerLoadBalancerType(TYPE_NAME, WeightedTargetLoadBalancer);
 }
 exports.setup = setup;
-//# sourceMappingURL=load-balancer-weighted-target.js.map

--- a/package/build/src/load-balancer.js
+++ b/package/build/src/load-balancer.js
@@ -55,4 +55,3 @@ function registerAll() {
     load_balancer_weighted_target.setup();
 }
 exports.registerAll = registerAll;
-//# sourceMappingURL=load-balancer.js.map

--- a/package/build/src/load-balancing-config.js
+++ b/package/build/src/load-balancing-config.js
@@ -115,4 +115,3 @@ function validateConfig(obj) {
     throw new Error('No recognized load balancing policy configured');
 }
 exports.validateConfig = validateConfig;
-//# sourceMappingURL=load-balancing-config.js.map

--- a/package/build/src/logging.js
+++ b/package/build/src/logging.js
@@ -60,4 +60,3 @@ function trace(severity, tracer, text) {
     }
 }
 exports.trace = trace;
-//# sourceMappingURL=logging.js.map

--- a/package/build/src/make-client.js
+++ b/package/build/src/make-client.js
@@ -126,4 +126,3 @@ function loadPackageDefinition(packageDef) {
     return result;
 }
 exports.loadPackageDefinition = loadPackageDefinition;
-//# sourceMappingURL=make-client.js.map

--- a/package/build/src/max-message-size-filter.js
+++ b/package/build/src/max-message-size-filter.js
@@ -78,4 +78,3 @@ class MaxMessageSizeFilterFactory {
     }
 }
 exports.MaxMessageSizeFilterFactory = MaxMessageSizeFilterFactory;
-//# sourceMappingURL=max-message-size-filter.js.map

--- a/package/build/src/metadata.js
+++ b/package/build/src/metadata.js
@@ -247,4 +247,3 @@ class Metadata {
     }
 }
 exports.Metadata = Metadata;
-//# sourceMappingURL=metadata.js.map

--- a/package/build/src/picker.js
+++ b/package/build/src/picker.js
@@ -83,4 +83,3 @@ class QueuePicker {
     }
 }
 exports.QueuePicker = QueuePicker;
-//# sourceMappingURL=picker.js.map

--- a/package/build/src/resolver-dns.js
+++ b/package/build/src/resolver-dns.js
@@ -224,4 +224,3 @@ function setup() {
     resolver_1.registerDefaultScheme('dns');
 }
 exports.setup = setup;
-//# sourceMappingURL=resolver-dns.js.map

--- a/package/build/src/resolver-uds.js
+++ b/package/build/src/resolver-uds.js
@@ -41,4 +41,3 @@ function setup() {
     resolver_1.registerResolver('unix', UdsResolver);
 }
 exports.setup = setup;
-//# sourceMappingURL=resolver-uds.js.map

--- a/package/build/src/resolver.js
+++ b/package/build/src/resolver.js
@@ -92,4 +92,3 @@ function registerAll() {
     resolver_uds.setup();
 }
 exports.registerAll = registerAll;
-//# sourceMappingURL=resolver.js.map

--- a/package/build/src/resolving-load-balancer.js
+++ b/package/build/src/resolving-load-balancer.js
@@ -206,4 +206,3 @@ class ResolvingLoadBalancer {
     }
 }
 exports.ResolvingLoadBalancer = ResolvingLoadBalancer;
-//# sourceMappingURL=resolving-load-balancer.js.map

--- a/package/build/src/server-call.js
+++ b/package/build/src/server-call.js
@@ -495,4 +495,3 @@ function handleExpiredDeadline(call) {
     call.cancelled = true;
     call.emit('cancelled', 'deadline');
 }
-//# sourceMappingURL=server-call.js.map

--- a/package/build/src/server-credentials.js
+++ b/package/build/src/server-credentials.js
@@ -78,4 +78,3 @@ class SecureServerCredentials extends ServerCredentials {
         return this.options;
     }
 }
-//# sourceMappingURL=server-credentials.js.map

--- a/package/build/src/server.js
+++ b/package/build/src/server.js
@@ -454,4 +454,3 @@ function handleBidiStreaming(call, handler, metadata) {
     }
     handler.func(stream);
 }
-//# sourceMappingURL=server.js.map

--- a/package/build/src/service-config.js
+++ b/package/build/src/service-config.js
@@ -261,4 +261,3 @@ function extractAndSelectServiceConfig(txtRecord, percentage) {
     return null;
 }
 exports.extractAndSelectServiceConfig = extractAndSelectServiceConfig;
-//# sourceMappingURL=service-config.js.map

--- a/package/build/src/status-builder.js
+++ b/package/build/src/status-builder.js
@@ -65,4 +65,3 @@ class StatusBuilder {
     }
 }
 exports.StatusBuilder = StatusBuilder;
-//# sourceMappingURL=status-builder.js.map

--- a/package/build/src/stream-decoder.js
+++ b/package/build/src/stream-decoder.js
@@ -93,4 +93,3 @@ class StreamDecoder {
     }
 }
 exports.StreamDecoder = StreamDecoder;
-//# sourceMappingURL=stream-decoder.js.map

--- a/package/build/src/subchannel-pool.js
+++ b/package/build/src/subchannel-pool.js
@@ -137,4 +137,3 @@ function getSubchannelPool(global) {
     }
 }
 exports.getSubchannelPool = getSubchannelPool;
-//# sourceMappingURL=subchannel-pool.js.map

--- a/package/build/src/subchannel.js
+++ b/package/build/src/subchannel.js
@@ -578,4 +578,3 @@ class Subchannel {
     }
 }
 exports.Subchannel = Subchannel;
-//# sourceMappingURL=subchannel.js.map

--- a/package/build/src/tls-helpers.js
+++ b/package/build/src/tls-helpers.js
@@ -23,4 +23,3 @@ function getDefaultRootsData() {
     return null;
 }
 exports.getDefaultRootsData = getDefaultRootsData;
-//# sourceMappingURL=tls-helpers.js.map

--- a/package/build/src/uri-parser.js
+++ b/package/build/src/uri-parser.js
@@ -108,4 +108,3 @@ function uriToString(uri) {
     return result;
 }
 exports.uriToString = uriToString;
-//# sourceMappingURL=uri-parser.js.map


### PR DESCRIPTION
When source map annotations are present, but the maps themselves are missing, it generates devtools warnings which annoy people like me. I'm submitting this change to fix those warnings.

Depends on https://github.com/ExodusMovement/grpc-js/pull/1

